### PR TITLE
Fix import file reset after load

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -553,6 +553,7 @@ document.getElementById('importFile').addEventListener('change', e => {
   reader.onload = () => {
     localStorage.setItem('savedCharacterLayout', reader.result);
     loadCharacters();
+    e.target.value = '';
   };
   reader.readAsText(file);
 });


### PR DESCRIPTION
## Summary
- reset hidden file input after importing characters

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684561182a2c8327b9244f4f31fa0166