### PR TITLE
Fix z-index reset when loading layout

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -525,6 +525,12 @@ function loadCharacters() {
     span.addEventListener('click', () => selectChar(span));
   });
 
+  const maxZIndex = Math.max(
+    0,
+    ...[...zone.querySelectorAll('.char')].map(el => parseInt(el.style.zIndex) || 0)
+  );
+  zCounter = maxZIndex + 1;
+
   alert("Character loaded!");
 }
 


### PR DESCRIPTION
## Summary
- after loading characters, compute the highest z-index and update `zCounter`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845611a2efc8327a1a835892b5d10db